### PR TITLE
only show shell_eval when include_fs_tools is set

### DIFF
--- a/lib/tidewave/mcp/tools/eval.ex
+++ b/lib/tidewave/mcp/tools/eval.ex
@@ -55,7 +55,9 @@ defmodule Tidewave.MCP.Tools.Eval do
             }
           }
         },
-        callback: &shell_eval/1
+        callback: &shell_eval/1,
+        # for now, only include the shell tool if FS tools are also enabled
+        listable: fn connect_params -> not is_nil(connect_params["include_fs_tools"]) end
       }
     ]
   end

--- a/test/mcp/tools/eval_test.exs
+++ b/test/mcp/tools/eval_test.exs
@@ -70,5 +70,12 @@ defmodule Tidewave.MCP.Tools.EvalTest do
 
       assert message =~ "Command failed with status"
     end
+
+    test "is only listable if include_fs_tools is set" do
+      {tools, _} = Tidewave.MCP.Server.tools_and_dispatch()
+      assert %{listable: fun} = Enum.find(tools, fn %{name: name} -> name == "shell_eval" end)
+      assert fun.(%{"include_fs_tools" => "true"})
+      refute fun.(%{"other" => "params"})
+    end
   end
 end

--- a/test/mcp_integration_test.exs
+++ b/test/mcp_integration_test.exs
@@ -22,7 +22,11 @@ defmodule Tidewave.MCPIntegrationTest do
   test "does not include fs tools by default", %{request: request} do
     assert %{tools: tools} = request
     assert is_list(tools)
-    refute "list_project_files" in Enum.map(tools, & &1["name"])
+
+    tool_names = Enum.map(tools, & &1["name"])
+
+    refute "list_project_files" in tool_names
+    refute "shell_eval" in tool_names
   end
 
   test "connects to SSE endpoint and receives tools on initialize", %{request: request} do


### PR DESCRIPTION
Closes https://github.com/tidewave-ai/tidewave_phoenix/issues/8.