### PR TITLE
Support custom tools for the MCP server

### DIFF
--- a/lib/tidewave/application.ex
+++ b/lib/tidewave/application.ex
@@ -4,8 +4,10 @@ defmodule Tidewave.Application do
 
   @impl true
   def start(_type, _args) do
+    tools = Application.get_env(:tidewave, :tools, [])
+
     children = [
-      Tidewave.MCP
+      {Tidewave.MCP, tools: tools}
     ]
 
     opts = [strategy: :one_for_one, name: Tidewave.Supervisor]

--- a/lib/tidewave/mcp.ex
+++ b/lib/tidewave/mcp.ex
@@ -10,10 +10,10 @@ defmodule Tidewave.MCP do
   end
 
   @impl true
-  def init(_init_arg) do
+  def init(init_arg) do
     silence_logs()
     add_logger_backend()
-    MCP.Server.init_tools()
+    MCP.Server.init_tools(init_arg[:tools])
 
     if Application.get_env(:tidewave, :root) == nil do
       Application.put_env(:tidewave, :root, File.cwd!())

--- a/lib/tidewave/mcp/server.ex
+++ b/lib/tidewave/mcp/server.ex
@@ -11,8 +11,8 @@ defmodule Tidewave.MCP.Server do
   @vsn Mix.Project.config()[:version]
 
   @doc false
-  def init_tools do
-    tools = raw_tools()
+  def init_tools(custom_tools) do
+    tools = List.flatten([raw_tools(), custom_tools])
     dispatch_map = Map.new(tools, fn tool -> {tool.name, tool.callback} end)
 
     :persistent_term.put({__MODULE__, :tools_and_dispatch}, {tools, dispatch_map})
@@ -34,7 +34,6 @@ defmodule Tidewave.MCP.Server do
       Tools.Phoenix.tools(),
       Tools.Hex.tools()
     ]
-    |> List.flatten()
   end
 
   defp tools(connect_params) do


### PR DESCRIPTION
Project specific tools might be very useful, additionally this will allow the creation of plugins with custom tools which can be added on your project's MCP server based on your needs.

If you are ok with this change I can add docs/tests.

POC:

```elixir
defmodule Demo.Tidewave do
  def tools do
    [
      %{
        name: "list_deps",
        description: """
        Returns the dependencies of the given project.
        """,
        inputSchema: %{type: "object", required: [], properties: %{}},
        callback: &list_deps/1
      }
    ]
  end

  def list_deps(_args) do
    {:ok, inspect([:hello, :mcp])}
  end
end
```

in the `runtime.exs`:

```elixir
config :tidewave, :tools, Demo.Tidewave.tools()
```

![image](https://github.com/user-attachments/assets/5b35054d-67a0-453c-abbf-e7a5a9b31973)
