### PR TITLE
Install only in dev environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can install Tidewave by adding the `tidewave` package to your list of depend
 ```elixir
 def deps do
   [
-    {:tidewave, "~> 0.1"}
+    {:tidewave, "~> 0.1", only: :dev}
   ]
 end
 ```


### PR DESCRIPTION
Fixes #24.

Had an issue deploying to production:
```
Notice: Application tidewave exited: Tidewave.Application.start(:normal, []) returned an error: shutdown: failed to start child: Tidewave.MCP
    ** (EXIT) an exception was raised:
        ** (UndefinedFunctionError) function Mix.Project.config/0 is undefined (module Mix.Project is not available)
            Mix.Project.config()
            (tidewave 0.1.0) lib/tidewave/mcp/tools/ecto.ex:137: Tidewave.MCP.Tools.Ecto.ecto_repos/0
            (tidewave 0.1.0) lib/tidewave/mcp/tools/ecto.ex:147: Tidewave.MCP.Tools.Ecto.repos_configured?/0
            (tidewave 0.1.0) lib/tidewave/mcp/tools/ecto.ex:7: Tidewave.MCP.Tools.Ecto.tools/0
            (tidewave 0.1.0) lib/tidewave/mcp/server.ex:32: Tidewave.MCP.Server.raw_tools/0
            (tidewave 0.1.0) lib/tidewave/mcp/server.ex:15: Tidewave.MCP.Server.init_tools/0
            (tidewave 0.1.0) lib/tidewave/mcp.ex:16: Tidewave.MCP.init/1
            (stdlib 6.2) supervisor.erl:869: :supervisor.init/1
Kernel pid terminated (application_controller) ("{application_start_failure,tidewave,{{shutdown,{failed_to_start_child,'Elixir.Tidewave.MCP',{undef,[{'Elixir.Mix.Project',config,[],[]},{'Elixir.Tidewave.MCP.Tools.Ecto',ecto_repos,0,[{file,\"lib/tidewave/mcp/tools/ecto.ex\"},{line,137}]},{'Elixir.Tidewave.MCP.Tools.Ecto','repos_configured?',0,[{file,\"lib/tidewave/mcp/tools/ecto.ex\"},{line,147}]},{'Elixir.Tidewave.MCP.Tools.Ecto',tools,0,[{file,\"lib/tidewave/mcp/tools/ecto.ex\"},{line,7}]},{'Elixir.Tidewave.MCP.Server',raw_tools,0,[{file,\"lib/tidewave/mcp/server.ex\"},{line,32}]},{'Elixir.Tidewave.MCP.Server',init_tools,0,[{file,\"lib/tidewave/mcp/server.ex\"},{line,15}]},{'Elixir.Tidewave.MCP',init,1,[{file,\"lib/tidewave/mcp.ex\"},{line,16}]},{supervisor,init,1,[{file,\"
```

Installing only in `dev` environment avoids that.