### PR TITLE
reply with 405 when POSTing to the SSE URL

### DIFF
--- a/lib/tidewave/router.ex
+++ b/lib/tidewave/router.ex
@@ -42,6 +42,12 @@ defmodule Tidewave.Router do
     |> halt()
   end
 
+  post "/mcp" do
+    conn
+    |> send_resp(405, "Method not allowed")
+    |> halt()
+  end
+
   post "/mcp/message" do
     Logger.metadata(tidewave_mcp: true)
 

--- a/test/tidewave_test.exs
+++ b/test/tidewave_test.exs
@@ -86,4 +86,12 @@ defmodule TidewaveTest do
 
     assert conn.status == 200
   end
+
+  test "405 when POSTing to /mcp" do
+    conn =
+      conn(:post, "/tidewave/mcp")
+      |> Tidewave.call([])
+
+    assert conn.status == 405
+  end
 end


### PR DESCRIPTION
also: always reply with 202 for message POSTs, since some clients don't like it when the server responds with a non-200 response (specifically the Rust SDK Client)