### PR TITLE
docs: add instructions for neovim

### DIFF
--- a/pages/editors/mcp.md
+++ b/pages/editors/mcp.md
@@ -4,6 +4,7 @@ You can integrate Tidewave into any editor or AI assistant that supports the Mod
 
   * [Claude Code and Claude Desktop](claude.md)
   * [Cursor](cursor.md)
+  * [Neovim](neovim.md)
   * [VS Code](vscode.md)
   * [Windsurf](windsurf.md)
   * [Zed](zed.md)

--- a/pages/editors/neovim.md
+++ b/pages/editors/neovim.md
@@ -1,0 +1,23 @@
+# Neovim
+
+You can use Tidewave with [Neovim](https://neovim.io/) through the [MCP Hub extension](https://github.com/ravitemer/mcphub.nvim),
+and integration with [Avante](https://github.com/ravitemer/mcphub.nvim/wiki/Avante) or
+[CodeCompanion](https://github.com/ravitemer/mcphub.nvim/wiki/CodeCompanion).
+
+With MCP Hub added, create a file at
+`~/.config/mcphub/servers.json` and add the following contents.
+
+```json
+{
+  "mcpServers": {
+    "tidewave": {
+      "url": "http://localhost:$PORT/tidewave/mcp"
+    }
+  }
+}
+```
+
+Where `$PORT` is the port your web application is running on.
+
+And you are good to go! If your application uses SQL database, you can verify
+it works by asking CodeCompanion/Avante to run `SELECT 1` as database query.


### PR DESCRIPTION
[rendered](https://github.com/arathunku/tidewave_phoenix/blob/arath-owkosqurlmpt/pages/editors/neovim.md)

As in the title, very simple instructions to add neovim support for Tidewave.

At this moment I didn't find any good way to configure&run it per project easily like with Claude Code. It might need some improvements to MCP Hub itself, see [discussion](https://github.com/ravitemer/mcphub.nvim/discussions/41).