### PR TITLE
Fix server.ex, arguments are optional according to spec.

### DIFF
--- a/lib/tidewave/mcp/server.ex
+++ b/lib/tidewave/mcp/server.ex
@@ -128,6 +128,10 @@ defmodule Tidewave.MCP.Server do
     result_or_error(request_id, dispatch(name, args, state_pid))
   end
 
+  def handle_call_tool(request_id, %{"name" => name}, state_pid) do
+    result_or_error(request_id, dispatch(name, %{}, state_pid))
+  end
+
   defp result_or_error(request_id, {:ok, text}) when is_binary(text) do
     result_or_error(request_id, {:ok, %{content: [%{type: "text", text: text}]}})
   end


### PR DESCRIPTION
Arguments are optional according to spec. 

Some tools do not need arguments, and in this case, MCP clients can send a tool request without the "arguments" key in the tool call json. 

https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-03-26/schema.ts#L716 

This fixes tools that don't need arguments for me on Windsurf editor. 