### PR TITLE
add Tidewave inspect_opts and use where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ The following options are available:
 
   * `:autoformat` - When writing Elixir source files, Tidewave will automatically format them with `mix format` by default. Setting this option to `false` disabled autoformatting.
 
+  * `:inspect_opts` - Custom options passed to `Kernel.inspect/2` when formatting some tool results.
+    Defaults to: `[charlists: :as_lists, limit: 50, pretty: true]`
+
 ## License
 
 Copyright (c) 2025 Dashbit

--- a/lib/tidewave.ex
+++ b/lib/tidewave.ex
@@ -8,7 +8,9 @@ defmodule Tidewave do
       allowed_origins: Keyword.get(opts, :allowed_origins, nil),
       sse_keepalive_timeout: Keyword.get(opts, :sse_keepalive_timeout, 15_000),
       allow_remote_access: Keyword.get(opts, :allow_remote_access, false),
-      phoenix_endpoint: nil
+      phoenix_endpoint: nil,
+      inspect_opts:
+        Keyword.get(opts, :inspect_opts, charlists: :as_lists, limit: 50, pretty: true)
     }
   end
 

--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -82,14 +82,14 @@ defmodule Tidewave.MCP.Tools.Ecto do
     end
   end
 
-  def execute_sql_query(%{"query" => query} = args, state) do
+  def execute_sql_query(%{"query" => query} = args, assigns) do
     repo =
       case args["repo"] do
         nil -> List.first(ecto_repos())
         repo -> Module.concat([repo])
       end
 
-    limit = Keyword.get(state.inspect_opts, :limit, 50)
+    limit = Keyword.get(assigns.inspect_opts, :limit, 50)
 
     case repo.query(query, args["arguments"] || []) do
       {:ok, result} ->
@@ -102,10 +102,10 @@ defmodule Tidewave.MCP.Tools.Ecto do
               ""
           end
 
-        {:ok, preamble <> inspect(result, state.inspect_opts)}
+        {:ok, preamble <> inspect(result, assigns.inspect_opts)}
 
       {:error, reason} ->
-        {:error, "Failed to execute query: #{inspect(reason, state.inspect_opts)}"}
+        {:error, "Failed to execute query: #{inspect(reason, assigns.inspect_opts)}"}
     end
   end
 

--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -59,7 +59,7 @@ defmodule Tidewave.MCP.Tools.Ecto do
               }
             }
           },
-          callback: &execute_sql_query/1
+          callback: &execute_sql_query/2
         },
         %{
           name: "get_ecto_schemas",
@@ -82,14 +82,14 @@ defmodule Tidewave.MCP.Tools.Ecto do
     end
   end
 
-  def execute_sql_query(%{"query" => query} = args) do
+  def execute_sql_query(%{"query" => query} = args, state) do
     repo =
       case args["repo"] do
         nil -> List.first(ecto_repos())
         repo -> Module.concat([repo])
       end
 
-    limit = 50
+    limit = Keyword.get(state.inspect_opts, :limit, 50)
 
     case repo.query(query, args["arguments"] || []) do
       {:ok, result} ->
@@ -102,10 +102,10 @@ defmodule Tidewave.MCP.Tools.Ecto do
               ""
           end
 
-        {:ok, preamble <> inspect(result, limit: limit, pretty: true)}
+        {:ok, preamble <> inspect(result, state.inspect_opts)}
 
       {:error, reason} ->
-        {:error, "Failed to execute query: #{inspect(reason)}"}
+        {:error, "Failed to execute query: #{inspect(reason, state.inspect_opts)}"}
     end
   end
 

--- a/lib/tidewave/mcp/tools/eval.ex
+++ b/lib/tidewave/mcp/tools/eval.ex
@@ -102,7 +102,7 @@ defmodule Tidewave.MCP.Tools.Eval do
       spawn_monitor(fn ->
         # we need to set the logger metadata again
         Logger.metadata(tidewave_mcp: true)
-        send(parent, {:result, eval_with_captured_io(code)})
+        send(parent, {:result, eval_with_captured_io(code, assigns.inspect_opts)})
       end)
 
     receive do
@@ -120,7 +120,7 @@ defmodule Tidewave.MCP.Tools.Eval do
     end
   end
 
-  defp eval_with_captured_io(code) do
+  defp eval_with_captured_io(code, inspect_opts) do
     result =
       capture_io(fn ->
         try do
@@ -131,15 +131,11 @@ defmodule Tidewave.MCP.Tools.Eval do
         end
       end)
 
-    inspect_all = fn i ->
-      inspect(i, limit: :infinity, printable_limit: :infinity, pretty: true)
-    end
-
     case result do
       # this is returned by IEx helpers
       {:"do not show this result in output", io} -> io
-      {result, ""} -> inspect_all.(result)
-      {result, io} -> "IO:\n\n#{io}\n\nResult:\n\n#{inspect_all.(result)}"
+      {result, ""} -> inspect(result, inspect_opts)
+      {result, io} -> "IO:\n\n#{io}\n\nResult:\n\n#{inspect(result, inspect_opts)}"
     end
   end
 

--- a/lib/tidewave/mcp/tools/fs.ex
+++ b/lib/tidewave/mcp/tools/fs.ex
@@ -171,7 +171,7 @@ defmodule Tidewave.MCP.Tools.FS do
     end
   end
 
-  def read_project_file(args, state) do
+  def read_project_file(args, assigns) do
     case args do
       %{"path" => path} ->
         line_offset = Map.get(args, "line_offset", 0)
@@ -180,15 +180,15 @@ defmodule Tidewave.MCP.Tools.FS do
         with {:ok, content} <- get_file_content(path, line_offset, count, !args["raw"]) do
           stat = File.stat!(path)
 
-          state =
+          assigns =
             Map.update(
-              state,
+              assigns,
               :read_timestamps,
               %{path => stat.mtime},
               &Map.put(&1, path, stat.mtime)
             )
 
-          {:ok, content, state}
+          {:ok, content, assigns}
         end
 
       _ ->
@@ -224,14 +224,14 @@ defmodule Tidewave.MCP.Tools.FS do
     end
   end
 
-  def write_project_file(args, state) do
+  def write_project_file(args, assigns) do
     case args do
       %{"path" => path, "content" => content} ->
-        read_timestamps = Map.get(state, :read_timestamps, %{})
+        read_timestamps = Map.get(assigns, :read_timestamps, %{})
 
         with {:ok, path} <- safe_path(path),
              :ok <- check_stale(path, read_timestamps, true) do
-          do_write_file(path, content, state)
+          do_write_file(path, content, assigns)
         end
 
       _ ->
@@ -241,18 +241,18 @@ defmodule Tidewave.MCP.Tools.FS do
 
   def edit_project_file(
         args,
-        state
+        assigns
       ) do
     case args do
       %{"path" => path, "old_string" => old_string, "new_string" => new_string} ->
-        read_timestamps = Map.get(state, :read_timestamps, %{})
+        read_timestamps = Map.get(assigns, :read_timestamps, %{})
 
         with {:ok, path} <- safe_path(path),
              :ok <- check_stale(path, read_timestamps),
              old_content = File.read!(path),
              :ok <- ensure_one_match(old_content, old_string) do
           new_content = String.replace(old_content, old_string, new_string)
-          do_write_file(path, new_content, state)
+          do_write_file(path, new_content, assigns)
         end
 
       _ ->
@@ -274,11 +274,11 @@ defmodule Tidewave.MCP.Tools.FS do
     end
   end
 
-  defp do_write_file(path, content, state) do
-    state = ensure_default_line_endings(state)
+  defp do_write_file(path, content, assigns) do
+    assigns = ensure_default_line_endings(assigns)
 
     content =
-      case Utils.detect_file_line_endings(path) || state.default_line_endings do
+      case Utils.detect_file_line_endings(path) || assigns.default_line_endings do
         :crlf -> String.replace(content, ["\r\n", "\n"], "\r\n")
         :lf -> content
       end
@@ -286,21 +286,21 @@ defmodule Tidewave.MCP.Tools.FS do
     File.mkdir_p!(Path.dirname(path))
 
     try do
-      content = maybe_autoformat(state, path, content)
+      content = maybe_autoformat(assigns, path, content)
       File.write!(path, content)
       stat = File.stat!(path)
 
-      state =
-        Map.update(state, :read_timestamps, %{path => stat.mtime}, &Map.put(&1, path, stat.mtime))
+      assigns =
+        Map.update(assigns, :read_timestamps, %{path => stat.mtime}, &Map.put(&1, path, stat.mtime))
 
-      {:ok, "Success!", state}
+      {:ok, "Success!", assigns}
     rescue
       e -> {:error, "Failed to format file: #{Exception.format(:error, e, __STACKTRACE__)}"}
     end
   end
 
-  defp maybe_autoformat(state, path, content) do
-    if Map.get(state, :autoformat, true) do
+  defp maybe_autoformat(assigns, path, content) do
+    if Map.get(assigns, :autoformat, true) do
       {fun, _opts} = Mix.Tasks.Format.formatter_for_file(path, root: MCP.root())
       fun.(content)
     else
@@ -488,8 +488,8 @@ defmodule Tidewave.MCP.Tools.FS do
     end
   end
 
-  defp ensure_default_line_endings(state) do
-    Map.put_new_lazy(state, :default_line_endings, fn ->
+  defp ensure_default_line_endings(assigns) do
+    Map.put_new_lazy(assigns, :default_line_endings, fn ->
       case GitLS.detect_line_endings() do
         {:ok, default_line_endings} -> default_line_endings
         {:error, _} -> :lf

--- a/lib/tidewave/mcp/tools/fs.ex
+++ b/lib/tidewave/mcp/tools/fs.ex
@@ -291,7 +291,12 @@ defmodule Tidewave.MCP.Tools.FS do
       stat = File.stat!(path)
 
       assigns =
-        Map.update(assigns, :read_timestamps, %{path => stat.mtime}, &Map.put(&1, path, stat.mtime))
+        Map.update(
+          assigns,
+          :read_timestamps,
+          %{path => stat.mtime},
+          &Map.put(&1, path, stat.mtime)
+        )
 
       {:ok, "Success!", assigns}
     rescue

--- a/lib/tidewave/mcp/tools/phoenix.ex
+++ b/lib/tidewave/mcp/tools/phoenix.ex
@@ -16,12 +16,12 @@ defmodule Tidewave.MCP.Tools.Phoenix do
           properties: %{},
           required: []
         },
-        callback: &list_liveview_pages/1
+        callback: &list_liveview_pages/2
       }
     ]
   end
 
-  def list_liveview_pages(_args) do
+  def list_liveview_pages(_args, assigns) do
     liveviews =
       for process <- Process.list(),
           result = liveview_process?(process),
@@ -35,7 +35,7 @@ defmodule Tidewave.MCP.Tools.Phoenix do
         {:ok, "There are no LiveView processes connected!"}
 
       liveviews ->
-        {:ok, inspect(liveviews, limit: :infinity, printable_limit: :infinity, pretty: true)}
+        {:ok, inspect(liveviews, assigns.inspect_opts)}
     end
   end
 

--- a/test/mcp/tools/eval_test.exs
+++ b/test/mcp/tools/eval_test.exs
@@ -21,7 +21,7 @@ defmodule Tidewave.MCP.Tools.EvalTest do
     test "evaluates simple Elixir expressions" do
       code = "1 + 1"
 
-      assert {:ok, "2", %{}} = Eval.project_eval(%{"code" => code}, %{})
+      assert {:ok, "2", %{}} = Eval.project_eval(%{"code" => code}, Tidewave.init([]))
     end
 
     test "evaluates complex Elixir expressions" do
@@ -33,13 +33,13 @@ defmodule Tidewave.MCP.Tools.EvalTest do
       Temp.add(40, 2)
       """
 
-      assert {:ok, "42", %{}} = Eval.project_eval(%{"code" => code}, %{})
+      assert {:ok, "42", %{}} = Eval.project_eval(%{"code" => code}, Tidewave.init([]))
     end
 
     test "returns formatted errors for exceptions" do
       code = "1 / 0"
 
-      assert {:ok, error, %{}} = Eval.project_eval(%{"code" => code}, %{})
+      assert {:ok, error, %{}} = Eval.project_eval(%{"code" => code}, Tidewave.init([]))
       assert error =~ "ArithmeticError"
       assert error =~ "bad argument in arithmetic expression"
     end
@@ -47,24 +47,30 @@ defmodule Tidewave.MCP.Tools.EvalTest do
     test "can use IEx helpers" do
       code = "h Tidewave"
 
-      assert {:ok, docs, %{}} = Eval.project_eval(%{"code" => code}, %{})
+      assert {:ok, docs, %{}} = Eval.project_eval(%{"code" => code}, Tidewave.init([]))
 
       assert docs =~ "Tidewave"
     end
 
     test "catches exits" do
       assert {:error, "Failed to evaluate code. Process exited with reason: :brutal_kill"} =
-               Eval.project_eval(%{"code" => "Process.exit(self(), :brutal_kill)"}, %{})
+               Eval.project_eval(
+                 %{"code" => "Process.exit(self(), :brutal_kill)"},
+                 Tidewave.init([])
+               )
     end
 
     test "times out" do
       assert {:error, "Evaluation timed out after 50 milliseconds."} =
-               Eval.project_eval(%{"code" => "Process.sleep(10_000)", "timeout" => 50}, %{})
+               Eval.project_eval(
+                 %{"code" => "Process.sleep(10_000)", "timeout" => 50},
+                 Tidewave.init([])
+               )
     end
 
     test "returns IO up to exception" do
       assert {:ok, result, %{}} =
-               Eval.project_eval(%{"code" => ~s[IO.puts("Hello!"); 1 / 0]}, %{})
+               Eval.project_eval(%{"code" => ~s[IO.puts("Hello!"); 1 / 0]}, Tidewave.init([]))
 
       assert result =~ "Hello!"
       assert result =~ "ArithmeticError"

--- a/test/mcp/tools/phoenix_test.exs
+++ b/test/mcp/tools/phoenix_test.exs
@@ -24,7 +24,7 @@ defmodule Tidewave.MCP.Tools.PhoenixTest do
       # which is difficult to test, so we'll just verify the function runs
       # and returns the expected format
       assert {:ok, "There are no LiveView processes connected!"} =
-               Phoenix.list_liveview_pages(%{})
+               Phoenix.list_liveview_pages(%{}, Tidewave.init([]))
 
       parent = self()
 
@@ -47,7 +47,7 @@ defmodule Tidewave.MCP.Tools.PhoenixTest do
           {:ready, lv_pid} -> lv_pid
         end
 
-      {:ok, text} = Phoenix.list_liveview_pages(%{})
+      {:ok, text} = Phoenix.list_liveview_pages(%{}, Tidewave.init([]))
 
       assert text =~ inspect(lv_pid)
       assert text =~ "view: Tidewave.MCP.Tools.PhoenixTest"

--- a/test/mcp/tools/process_test.exs
+++ b/test/mcp/tools/process_test.exs
@@ -100,7 +100,11 @@ defmodule Tidewave.MCP.Tools.ProcessTest do
       # start ping pong loop
       send(pid1, {:ping, pid2})
 
-      {:ok, result} = ProcessTool.trace_process(%{"pid" => inspect(pid1), "message_count" => 3})
+      {:ok, result} =
+        ProcessTool.trace_process(
+          %{"pid" => inspect(pid1), "message_count" => 3},
+          Tidewave.init([])
+        )
 
       lines = String.split(result, "\n")
 
@@ -116,11 +120,14 @@ defmodule Tidewave.MCP.Tools.ProcessTest do
       pid = spawn_link(fn -> Process.sleep(:infinity) end)
 
       assert {:ok, text} =
-               ProcessTool.trace_process(%{
-                 "pid" => inspect(pid),
-                 "message_count" => 10,
-                 "timeout" => 50
-               })
+               ProcessTool.trace_process(
+                 %{
+                   "pid" => inspect(pid),
+                   "message_count" => 10,
+                   "timeout" => 50
+                 },
+                 Tidewave.init([])
+               )
 
       assert text =~ "Timed out waiting for more messages"
     end


### PR DESCRIPTION
Closes https://github.com/tidewave-ai/tidewave_phoenix/issues/37.

@josevalim I changed it to also use those inspect_opts when formatting eval results, but maybe we want a higher limit there? We set it to infinity previously? On the other hand, preventing overly large responses may also be good. So I'm not sure...