### PR TITLE
VSCode setup: add note about enabling 'Editor Preview Features'

### DIFF
--- a/pages/editors/vscode.md
+++ b/pages/editors/vscode.md
@@ -3,8 +3,9 @@
 You can use Tidewave with Visual Studio Code through the [GitHub Copilot extension](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot).
 
 At the time of writing, MCP support in GitHub Copilot is in public preview and only
-available in "Agent" mode. Therefore the instructions below may be out of date.
-In any case, let's do this.
+available when **a)** the 'Editor Preview Features' flag is enabled in your GitHub
+settings and **b)** your Copilot session is in "Agent" mode. Given the preview state
+of the feature, the instructions below may be out of date. In any case, let's do this.
 
 Open up your AI assistant and then click on the red arrow in your editor (shown below)
 to enable "Agent" mode and then the Wrench icon (pointed by the green arrow) to


### PR DESCRIPTION
This pull request adds a note about the need to enable 'Editor Preview Features' in the user's GitHub settings. Bizarrely, VSCode allows you to _add_ an MCP server via the command palette, but it will silently fail to _connect_ to the MCP server unless this setting is flipped. The note I added may only be helpful for the preview period, but it would have saved me 30 minutes of misguided troubleshooting, and I suspect it may help other early adopters.