### PR TITLE
Claude Code ipv4 ip required

### DIFF
--- a/pages/editors/claude.md
+++ b/pages/editors/claude.md
@@ -94,7 +94,7 @@ Adding Tidewave to [Claude Code](https://docs.anthropic.com/en/docs/agents-and-t
 is straight-forward, just run:
 
 ```shell
-$ claude mcp add --transport sse tidewave http://localhost:$PORT/tidewave/mcp
+$ claude mcp add --transport sse tidewave http://127.0.0.1:$PORT/tidewave/mcp
 ```
 
 Where `$PORT` is the port your web application is running on. And you are good to go!


### PR DESCRIPTION
So I originally started off trying to get the MCP server working with opencode but switched to Claude Code because it was documented. 

I couldn't get it working for a while but the Claude Code error logs show that it only attempts to connect on the IPv6 loopback address. 

```
[
  {
    "error": "Error: SSE error: TypeError: fetch failed: connect ECONNREFUSED ::1:4000\n    at _eventSource.onerror (file:///Users/jbaldwin/.asdf/installs/nodejs/18.7.0/lib/node_modules/@anthropic-ai/claude-code/cli.js:2034:13930)\n    at _d.w40 (file:///Users/jbaldwin/.asdf/installs/nodejs/18.7.0/lib/node_modules/@anthropic-ai/claude-code/cli.js:2034:5137)\n    at file:///Users/jbaldwin/.asdf/installs/nodejs/18.7.0/lib/node_modules/@anthropic-ai/claude-code/cli.js:2034:2586\n    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)",
    "timestamp": "2025-05-03T00:55:56.286Z",
    "sessionId": "bc4d71aa-654c-4a21-84ef-fb4405d94a74",
    "cwd": "/Users/jbaldwin/repos/_projects/pair"
  },
  {
    "error": "Connection failed: SSE error: TypeError: fetch failed: connect ECONNREFUSED ::1:4000",
    "timestamp": "2025-05-03T00:55:56.287Z",
    "sessionId": "bc4d71aa-654c-4a21-84ef-fb4405d94a74",
    "cwd": "/Users/jbaldwin/repos/_projects/pair"
  }
]
```

If I changed the server to the IPv4 loopback address then it worked:
`claude add --transport sse tidewave http://127.0.0l.1:4000/tidewave/mcp`

I also tried keeping `localhost` and updating my `dev.exs` config to bind got the IPv6 `any` address: `  http: [ip: {0, 0, 0, 0, 0, 0, 0, 0}, port: 4000]` and that worked as well!

**I'm not sure if this doc change is a good idea**, or if it's been working for other people with just `localhost` and something is just wrong with my dev env, but I figured this might be helpful to someone else.


p.s. Still couldn't get it working with opencode, but if I do I'll add some docs 😄 