### PR TITLE
send stderr to group leader

### DIFF
--- a/lib/tidewave/mcp.ex
+++ b/lib/tidewave/mcp.ex
@@ -21,7 +21,8 @@ defmodule Tidewave.MCP do
 
     children = [
       {Registry, name: MCP.Registry, keys: :unique},
-      Tidewave.MCP.Logger
+      Tidewave.MCP.Logger,
+      {Tidewave.MCP.IOForwardGL, name: :standard_error}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)

--- a/lib/tidewave/mcp/io_forward_gl.ex
+++ b/lib/tidewave/mcp/io_forward_gl.ex
@@ -75,7 +75,7 @@ defmodule Tidewave.MCP.IOForwardGL do
           send(group_leader, {:io_request, self(), reply_as, req})
 
         _ ->
-          send(from, {:io_reply, reply_as, {:error, :terminated}})
+          :ok
       end
     end)
 

--- a/lib/tidewave/mcp/io_forward_gl.ex
+++ b/lib/tidewave/mcp/io_forward_gl.ex
@@ -1,0 +1,69 @@
+# This file is based on: https://github.com/livebook-dev/livebook/blob/main/lib/livebook/runtime/erl_dist/io_forward_gl.ex
+# licensed under Apache License 2.0
+# https://github.com/livebook-dev/livebook/blob/main/LICENSE
+
+defmodule Tidewave.MCP.IOForwardGL do
+  # An IO device process forwarding all requests to sender's group
+  # leader.
+  #
+  # We register this device as `:standard_error` in order to capture
+  # compile errors etc., but still forward them to the real stderr.
+  #
+  # The process implements [The Erlang I/O Protocol](https://erlang.org/doc/apps/stdlib/io_protocol.html)
+  # and can be thought of as a virtual IO device.
+
+  use GenServer
+
+  @doc """
+  Starts the IO device.
+
+  ## Options
+
+    * `:name` - the name to register the process under. Optional.
+      If the name is already used, it will be unregistered before
+      starting the process and registered back when the server
+      terminates
+
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = opts[:name]
+
+    if previous = name && Process.whereis(name) do
+      Process.unregister(name)
+    end
+
+    GenServer.start_link(__MODULE__, {name, previous}, opts)
+  end
+
+  @impl true
+  def init({name, previous}) do
+    Process.flag(:trap_exit, true)
+    {:ok, %{name: name, previous: previous}}
+  end
+
+  @impl true
+  def handle_info({:io_request, from, reply_as, req}, state) do
+    case Process.info(from, :group_leader) do
+      {:group_leader, group_leader} ->
+        # Forward the request to sender's group leader and instruct
+        # it to get back to the sender.
+        send(group_leader, {:io_request, from, reply_as, req})
+
+      _ ->
+        send(from, {:io_reply, reply_as, {:error, :terminated}})
+    end
+
+    {:noreply, state}
+  end
+
+  @impl true
+  def terminate(_, %{name: name, previous: previous}) do
+    if name && previous do
+      Process.unregister(name)
+      Process.register(previous, name)
+    end
+
+    :ok
+  end
+end

--- a/lib/tidewave/mcp/tools/eval.ex
+++ b/lib/tidewave/mcp/tools/eval.ex
@@ -2,7 +2,9 @@ defmodule Tidewave.MCP.Tools.Eval do
   @moduledoc false
 
   @compile {:no_warn_undefined, Phoenix.CodeReloader}
+
   alias Tidewave.MCP
+  alias Tidewave.MCP.IOForwardGL
 
   def tools do
     [
@@ -123,12 +125,14 @@ defmodule Tidewave.MCP.Tools.Eval do
   defp eval_with_captured_io(code, inspect_opts) do
     result =
       capture_io(fn ->
-        try do
-          {result, _bindings} = Code.eval_string(code, [], env())
-          result
-        catch
-          kind, reason -> Exception.format(kind, reason, __STACKTRACE__)
-        end
+        IOForwardGL.with_forwarded_io(:standard_error, fn ->
+          try do
+            {result, _bindings} = Code.eval_string(code, [], env())
+            result
+          catch
+            kind, reason -> Exception.format(kind, reason, __STACKTRACE__)
+          end
+        end)
       end)
 
     case result do

--- a/test/mcp/io_forward_gl_test.exs
+++ b/test/mcp/io_forward_gl_test.exs
@@ -1,0 +1,43 @@
+defmodule Tidewave.MCP.IOForwardGLTest do
+  use ExUnit.Case, async: true
+
+  alias Tidewave.MCP.IOForwardGL
+
+  defmacrop eventually(interval, tries, fun) do
+    quote do
+      assert Stream.interval(unquote(interval))
+             |> Stream.take(unquote(tries))
+             |> Enum.reduce_while(nil, fn _, _ ->
+               if unquote(fun).() do
+                 {:halt, true}
+               else
+                 {:cont, false}
+               end
+             end),
+             "expected function to return true after #{unquote(tries)} attempts"
+    end
+  end
+
+  test "cleans up when owner dies" do
+    gl_pid = spawn_link(fn -> Process.sleep(:infinity) end)
+
+    pid =
+      spawn(fn ->
+        Process.group_leader(self(), gl_pid)
+
+        IOForwardGL.with_forwarded_io(:standard_error, fn ->
+          Process.sleep(10000)
+        end)
+      end)
+
+    eventually(100, 10, fn ->
+      Map.has_key?(:sys.get_state(:standard_error).targets, gl_pid)
+    end)
+
+    Process.exit(pid, :brutal_kill)
+
+    eventually(100, 10, fn ->
+      not Map.has_key?(:sys.get_state(:standard_error).targets, gl_pid)
+    end)
+  end
+end

--- a/test/mcp/tools/eval_test.exs
+++ b/test/mcp/tools/eval_test.exs
@@ -75,6 +75,16 @@ defmodule Tidewave.MCP.Tools.EvalTest do
       assert result =~ "Hello!"
       assert result =~ "ArithmeticError"
     end
+
+    test "captures standard_error" do
+      assert {:ok, result, %{}} =
+               Eval.project_eval(
+                 %{"code" => "hello"},
+                 Tidewave.init([])
+               )
+
+      assert result =~ "undefined variable \"hello\""
+    end
   end
 
   describe "shell_eval/1" do


### PR DESCRIPTION
Closes https://github.com/tidewave-ai/tidewave_phoenix/issues/54

@josevalim I tried forwarding it to the original stderr as well, but I did not find a good condition to check, so it ended up printing twice (group leader stdout and stderr). But I think this may be fine.