### PR TITLE
allow any error reason when chunk fails

### DIFF
--- a/lib/tidewave/mcp/connection.ex
+++ b/lib/tidewave/mcp/connection.ex
@@ -102,7 +102,7 @@ defmodule Tidewave.MCP.Connection do
   def handle_cast({:send_sse_message, message}, state) do
     case handle_sse_message(state.conn, state.session_id, message) do
       {:ok, conn} -> {:noreply, %{state | conn: conn}}
-      {:error, :closed} -> {:stop, {:shutdown, :closed}, state}
+      {:error, reason} -> {:stop, {:shutdown, reason}, state}
     end
   end
 
@@ -228,8 +228,8 @@ defmodule Tidewave.MCP.Connection do
         schedule_next_ping(state.assigns)
         {:noreply, state}
 
-      {:error, :closed} ->
-        {:stop, {:shutdown, :closed}, state}
+      {:error, reason} ->
+        {:stop, {:shutdown, reason}, state}
     end
   end
 
@@ -263,7 +263,7 @@ defmodule Tidewave.MCP.Connection do
 
     case chunk(conn, "event: close\ndata: #{reason}\n\n") do
       {:ok, conn} -> halt(conn)
-      {:error, :closed} -> halt(conn)
+      {:error, _reason} -> halt(conn)
     end
   end
 
@@ -273,7 +273,7 @@ defmodule Tidewave.MCP.Connection do
 
     case chunk(conn, sse_message) do
       {:ok, conn} -> {:ok, conn}
-      {:error, :closed} -> {:error, :closed}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -292,7 +292,7 @@ defmodule Tidewave.MCP.Connection do
            "\n\n"
          ]) do
       {:ok, conn} -> {:ok, %{state | conn: conn}}
-      {:error, :closed} -> {:error, :closed}
+      {:error, reason} -> {:error, reason}
     end
   end
 end

--- a/lib/tidewave/mcp/sse.ex
+++ b/lib/tidewave/mcp/sse.ex
@@ -175,7 +175,7 @@ defmodule Tidewave.MCP.SSE do
 
     case chunk(conn, "event: endpoint\ndata: #{endpoint}\n\n") do
       {:ok, conn} -> conn
-      {:error, :closed} -> conn
+      {:error, _reason} -> conn
     end
   end
 


### PR DESCRIPTION
Fixes

```
[error] GenServer #PID<0.1074.0> terminating
** (CaseClauseError) no case clause matching: {:error, "closed"}
    (tidewave 0.1.4) lib/tidewave/mcp/connection.ex:289: Tidewave.MCP.Connection.handle_ping/1
    (tidewave 0.1.4) lib/tidewave/mcp/connection.ex:226: Tidewave.MCP.Connection.handle_info/2
    (stdlib 6.2) gen_server.erl:2345: :gen_server.try_handle_info/3
    (stdlib 6.2) gen_server.erl:2433: :gen_server.handle_msg/6
    (tidewave 0.1.4) lib/tidewave/mcp/sse.ex:185: Tidewave.MCP.SSE.enter_loop/2
    ...
```