### PR TITLE
Fix incorrect key usage in ecto.ex

### DIFF
--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -118,7 +118,7 @@ defmodule Tidewave.MCP.Tools.Ecto do
       for module <- project_modules(),
           Code.ensure_loaded?(module),
           function_exported?(module, :__changeset__, 0) do
-        case Source.get_source_location(%{"module" => inspect(module)}) do
+        case Source.get_source_location(%{"reference" => inspect(module)}) do
           {:ok, source_file} ->
             %{module: inspect(module), source_file: source_file}
 


### PR DESCRIPTION
Ecto.get_ecto_schemas has a mistake here I believe (old key used in the passed Map?).

Not sure if I'm missing something, but this appears to have been a regression which affects my local latest 0.1.6; used to work fine in an earlier version AFAIK.