### PR TITLE
Remove extra prefix from logs output

### DIFF
--- a/lib/tidewave/mcp/tools/logs.ex
+++ b/lib/tidewave/mcp/tools/logs.ex
@@ -28,8 +28,7 @@ defmodule Tidewave.MCP.Tools.Logs do
   def get_logs(args) do
     case args do
       %{"tail" => n} ->
-        {:ok,
-         "The last #{n} log entries are:\n\n#{Enum.join(Tidewave.MCP.Logger.get_logs(n), "\n")}"}
+        {:ok, Enum.join(Tidewave.MCP.Logger.get_logs(n), "\n")}
 
       _ ->
         {:error, :invalid_arguments}


### PR DESCRIPTION
Currently the `get_logs` tool includes `The last N log entries are:`, but that is basically already implied by the tool call. In Rails we [return logs without prefix](https://github.com/tidewave-ai/tidewave_rails/blob/ef380a1600fe509590a40ceacfda626afa5f614c/lib/tidewave/tools/get_logs.rb#L20), so I would remove the prefix for consistency.