### PR TITLE
apply timeout from arguments and reply with error

### DIFF
--- a/lib/tidewave/mcp/connection.ex
+++ b/lib/tidewave/mcp/connection.ex
@@ -94,7 +94,7 @@ defmodule Tidewave.MCP.Connection do
     timeout =
       case args do
         %{"timeout" => timeout} when is_integer(timeout) ->
-          timeout
+          timeout + 1000
 
         _ ->
           30000


### PR DESCRIPTION
Fixes crash instead of reply when tool call raises an exception (for example when passing a string to an SQL query that expects a UUID).