### PR TITLE
Assume git is always present

### DIFF
--- a/lib/tidewave/mcp.ex
+++ b/lib/tidewave/mcp.ex
@@ -2,6 +2,7 @@ defmodule Tidewave.MCP do
   @moduledoc false
 
   use Supervisor
+  require Logger
 
   alias Tidewave.MCP
 
@@ -65,26 +66,14 @@ defmodule Tidewave.MCP do
       Application.put_env(:tidewave, :root, File.cwd!())
     end
 
-    if Application.get_env(:tidewave, :git_root) == nil do
-      git_root =
-        if System.find_executable("git") do
-          case System.cmd("git", ["rev-parse", "--show-toplevel"]) do
-            {path, 0} ->
-              String.trim(path)
-
-            {_, _} ->
-              tmp_dir = Path.join(Mix.Project.build_path(), "tmp")
-              git_dir = Path.join(tmp_dir, ".git")
-
-              if not File.dir?(git_dir) do
-                {_, 0} = System.cmd("git", ["init", tmp_dir])
-              end
-
-              tmp_dir
-          end
-        end
-
-      Application.put_env(:tidewave, :git_root, git_root)
+    if System.find_executable("git") &&
+         match?({_, 0}, System.cmd("git", ["rev-parse", "--show-toplevel"])) do
+      :ok
+    else
+      Logger.warning(
+        "Some Tidewave tools are only available for codebases using `git`. " <>
+          "Make sure `git` is installed and run `git init` before continuing"
+      )
     end
 
     if Application.get_env(:tidewave, :project_name) == nil do

--- a/lib/tidewave/mcp/git_ls.ex
+++ b/lib/tidewave/mcp/git_ls.ex
@@ -4,26 +4,10 @@ defmodule Tidewave.MCP.GitLS do
   alias Tidewave.MCP
 
   def list_files(opts \\ []) do
-    execute_git(fn git_dir -> list_files(git_dir, opts) end)
-  end
-
-  def detect_line_endings do
-    execute_git(&detect_line_endings/1)
-  end
-
-  defp execute_git(fun) do
-    if git = MCP.git_root() do
-      fun.(Path.join(git, ".git"))
-    else
-      {:error, "This tool requires git to be installed and available in the PATH."}
-    end
-  end
-
-  defp list_files(git_dir, opts) do
     glob_pattern = Keyword.get(opts, :glob)
     include_ignored = Keyword.get(opts, :include_ignored, false)
 
-    args = ["--git-dir", git_dir, "ls-files", "--cached", "--others"]
+    args = ["ls-files", "--cached", "--others"]
     args = if glob_pattern, do: args ++ [glob_pattern], else: args
     args = if include_ignored, do: args, else: args ++ ["--exclude-standard"]
 
@@ -34,16 +18,8 @@ defmodule Tidewave.MCP.GitLS do
     end
   end
 
-  defp detect_line_endings(git_dir) do
-    args = [
-      "--git-dir",
-      git_dir,
-      "ls-files",
-      "--cached",
-      "--others",
-      "--exclude-standard",
-      "--eol"
-    ]
+  def detect_line_endings do
+    args = ["ls-files", "--cached", "--others", "--exclude-standard", "--eol"]
 
     with {result, 0} <- System.cmd("git", args, cd: MCP.root()) do
       {:ok, parse_line_endings(result)}

--- a/test/mcp/tools/fs_sync_test.exs
+++ b/test/mcp/tools/fs_sync_test.exs
@@ -9,6 +9,7 @@ defmodule Tidewave.MCP.Tools.FSSyncTest do
       # Change to the test directory to make grep search there
       original_dir = File.cwd!()
       File.cd!(tmp_dir)
+      System.cmd("git", ["init"])
 
       # also overwrite the stored MCP working directory
       old_root = Application.get_env(:tidewave, :root)


### PR DESCRIPTION
If we want to detect line endings in the Tidewave client, we will likely need to pass the git root to the client (or we assume the repo is in a git root, perhaps by making it so Phoenix `mix phx.new` always runs `git init`?). 