### PR TITLE
Include elixir and otp versions in tc config

### DIFF
--- a/lib/tidewave/router.ex
+++ b/lib/tidewave/router.ex
@@ -133,6 +133,8 @@ defmodule Tidewave.Router do
       credentials: Map.new(credentials),
       framework: %{
         type: "phoenix",
+        elixir_version: System.version(),
+        otp_version: System.otp_release(),
         tidewave_version: package_version(:tidewave),
         phoenix_version: package_version(:phoenix),
         live_view_version: package_version(:phoenix_live_view)


### PR DESCRIPTION
I wonder if we should instead get all those versions using project_eval, otherwise adding more information always requires a new `:tidewave` release and bump, which is more friction. Thoughts?