### PR TITLE
Fix links: swap Claude Code and Claude Desktop URLs

### DIFF
--- a/pages/editors/mcp.md
+++ b/pages/editors/mcp.md
@@ -2,8 +2,8 @@
 
 You can integrate Tidewave into any editor or AI assistant that supports the Model Context Protocol (MCP). We have tailored instructions for some of them:
 
-  * [Claude Code](claude.md)
-  * [Claude Desktop](claude_code.md)
+  * [Claude Code](claude_code.md)
+  * [Claude Desktop](claude.md)
   * [Cursor](cursor.md)
   * [Neovim](neovim.md)
   * [opencode](opencode.md)


### PR DESCRIPTION
Fixed swapped links for Claude Code and Claude Desktop in the documentation to point correctly.