### PR TITLE
Format search_package_docs as text

### DIFF
--- a/lib/tidewave/mcp/tools/hex.ex
+++ b/lib/tidewave/mcp/tools/hex.ex
@@ -61,7 +61,7 @@ defmodule Tidewave.MCP.Tools.Hex do
 
         case Req.get("https://search.hexdocs.pm/", opts) do
           {:ok, %{status: 200, body: body}} ->
-            {:ok, Jason.encode!(body)}
+            {:ok, format_results(body)}
 
           {:ok, %{status: status, body: body}} ->
             {:error, "HTTP error #{status} - #{inspect(body)}"}
@@ -133,5 +133,32 @@ defmodule Tidewave.MCP.Tools.Hex do
 
   defp req_opts do
     Application.get_env(:tidewave, :hex_req_opts, [])
+  end
+
+  defp format_results(body) do
+    %{"found" => found, "hits" => hits} = body
+
+    result = "Results: #{found}"
+
+    hits
+    |> Enum.with_index()
+    |> Enum.reduce(result, fn {hit, index}, result ->
+      %{
+        "document" => %{
+          "doc" => doc,
+          "package" => package,
+          "ref" => ref,
+          "title" => title
+        }
+      } = hit
+
+      result <>
+        "\n\n" <>
+        """
+        <result index="#{index}" package="#{package}" ref="#{ref}" title="#{title}">
+        #{doc}
+        </result>
+        """
+    end)
   end
 end

--- a/test/mcp/tools/hex_test.exs
+++ b/test/mcp/tools/hex_test.exs
@@ -14,16 +14,29 @@ defmodule Tidewave.MCP.Tools.HexTest do
         assert conn.query_params["filter_by"] =~ "plug"
 
         Req.Test.json(conn, %{
+          "found" => 1,
           "hits" => [
             %{
-              "title" => "Phoenix.Controller",
-              "doc" => "Controller functionality for Phoenix"
+              "document" => %{
+                "title" => "Phoenix.Controller",
+                "package" => "phoenix-1.8.0",
+                "ref" => "Phoenix.Controller.html",
+                "doc" => "Controller functionality for Phoenix"
+              }
             }
           ]
         })
       end)
 
-      assert {:ok, _} = Hex.search_package_docs(%{"q" => "controller"})
+      assert {:ok, result} = Hex.search_package_docs(%{"q" => "controller"})
+
+      assert result == """
+             Results: 1
+
+             <result index="0" package="phoenix-1.8.0" ref="Phoenix.Controller.html" title="Phoenix.Controller">
+             Controller functionality for Phoenix
+             </result>
+             """
     end
 
     test "can provide list of packages" do
@@ -38,10 +51,15 @@ defmodule Tidewave.MCP.Tools.HexTest do
             assert conn.query_params["filter_by"] == "package:=[phoenix-1.7.35]"
 
             Req.Test.json(conn, %{
+              "found" => 1,
               "hits" => [
                 %{
-                  "title" => "Phoenix.Controller",
-                  "doc" => "Controller functionality for Phoenix"
+                  "document" => %{
+                    "title" => "Phoenix.Controller",
+                    "package" => "phoenix-1.8.0",
+                    "ref" => "Phoenix.Controller.html",
+                    "doc" => "Controller functionality for Phoenix"
+                  }
                 }
               ]
             })


### PR DESCRIPTION
Currently the `search_package_docs` tool returns raw JSON from the Typesense API. Some of the fields in the response are not relevant for the LLM at all, and since the docs are a JSON string, any quotes are escaped, which can be further confusing.

This PR changes the formatting to text, with an xml-ish tag wrapping each result.