### PR TITLE
Removes Empty Items Type Descriptor Map for Arguments Array in Ecto and Eval Tools

### DIFF
--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -57,8 +57,7 @@ defmodule Tidewave.MCP.Tools.Ecto do
               arguments: %{
                 type: "array",
                 description:
-                  "The arguments to pass to the query. The query must contain corresponding parameters.",
-                items: %{}
+                  "The arguments to pass to the query. The query must contain corresponding parameters."
               }
             }
           },

--- a/lib/tidewave/mcp/tools/eval.ex
+++ b/lib/tidewave/mcp/tools/eval.ex
@@ -34,8 +34,7 @@ defmodule Tidewave.MCP.Tools.Eval do
             arguments: %{
               type: "array",
               description:
-                "The arguments to pass to evaluation. They are available inside the evaluated code as `arguments`.",
-              items: %{}
+                "The arguments to pass to evaluation. They are available inside the evaluated code as `arguments`."
             },
             timeout: %{
               type: "integer",


### PR DESCRIPTION
Addresses [Gemini-CLI Issue #162 ](https://github.com/tidewave-ai/tidewave_phoenix/issues/162)