### PR TITLE
Update MCP docs: Streamable HTTP, wording tweaks

### DIFF
--- a/pages/mcp/mcp.md
+++ b/pages/mcp/mcp.md
@@ -17,7 +17,9 @@ Tidewave MCP includes only a subset of the features in Tidewave. In-browser agen
 
 ## General instructions
 
-Add the Tidewave MCP server to your editor or agent configuration as the type "http" (for Phoenix) or "sse" (for Rails), pointing to the `/tidewave/mcp` path of port your web application is running on. For example, `http://localhost:4000/tidewave/mcp`.
+Add the Tidewave MCP server to your editor or MCP client configuration as the type "http" (streamable) for Phoenix or "sse" for Rails, pointing to the `/tidewave/mcp` path and port your web application is running on. For example, `http://localhost:4000/tidewave/mcp`.
+
+If your MCP client has an option to use the Streamable HTTP transport, enable it. Otherwise, your client may receive a 'method not allowed' error response.
 
 In case your tool of choice only supports "io" servers, you can use one of the many available [MCP proxies](../guides/mcp_proxy.md).
 

--- a/pages/mcp/mcp.md
+++ b/pages/mcp/mcp.md
@@ -1,6 +1,8 @@
 # Setting up Tidewave MCP
 
-You can access some of Tidewave features from your editor via the Model Context Protocol (MCP). We have tailored instructions for some of them:
+You can access some of Tidewave's features from your editor or agent via the Model Context Protocol (MCP).
+
+We have tailored instructions for:
 
   * [Claude Code](claude_code.md)
   * [Claude Desktop](claude.md)
@@ -11,11 +13,11 @@ You can access some of Tidewave features from your editor via the Model Context 
   * [Windsurf](windsurf.md)
   * [Zed](zed.md)
 
-Tidewave MCP includes only a subset of the features in Tidewave. In-browser agents, point and click prompting, and contextual browser testing are part of [Tidewave Web](https://tidewave.ai) and are available under the `/tidewave` route of your application.
+Tidewave MCP includes only a subset of the features in Tidewave. In-browser agents, point-and-click prompting and contextual browser testing are part of [Tidewave Web](https://tidewave.ai) and are available under the `/tidewave` route of your application.
 
 ## General instructions
 
-Generally speaking, you need to include Tidewave as MCP of type "http" (for Phoenix) or "sse" (for Rails), pointing to the `/tidewave/mcp` path of port your web application is running on. For example, `http://localhost:4000/tidewave/mcp`.
+Add the Tidewave MCP server to your editor or agent configuration as the type "http" (for Phoenix) or "sse" (for Rails), pointing to the `/tidewave/mcp` path of port your web application is running on. For example, `http://localhost:4000/tidewave/mcp`.
 
 In case your tool of choice only supports "io" servers, you can use one of the many available [MCP proxies](../guides/mcp_proxy.md).
 


### PR DESCRIPTION
Motivated by the failure of Kilo Code to use Streaming HTTP data transport without being explicitly set to.

In particular, please check the 'Add setting of Streaming HTTP to general instructions; update curl test request' commit. I'm suggesting that the curl command should initiate a request that does not result in 'Method not allowed', which I understand now occurs with the previous curl command due to the requirement of the Streamable HTTP transport.

Thanks!