### PR TITLE
Remove Empty Item Type Descriptor Maps in Ecto and Eval Tools

### DIFF
--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -58,7 +58,7 @@ defmodule Tidewave.MCP.Tools.Ecto do
                 type: "array",
                 description:
                   "The arguments to pass to the query. The query must contain corresponding parameters.",
-                items: %{}
+                items: %{type: ["array", "boolean", "integer", "number", "object", "string"]}
               }
             }
           },

--- a/lib/tidewave/mcp/tools/eval.ex
+++ b/lib/tidewave/mcp/tools/eval.ex
@@ -35,7 +35,7 @@ defmodule Tidewave.MCP.Tools.Eval do
               type: "array",
               description:
                 "The arguments to pass to evaluation. They are available inside the evaluated code as `arguments`.",
-              items: %{}
+              items: %{type: ["array", "boolean", "integer", "number", "object", "string"]}
             },
             timeout: %{
               type: "integer",


### PR DESCRIPTION
This makes `Gemini-CLI` happy, but might or might not make other tools sad. It also comes with the possibility of future annoyance as the MCP & jsonrpc specs evolve.

See related [discussion here](https://github.com/tidewave-ai/tidewave_phoenix/issues/162), and probably ignore this until after ElixirConf in general. The list of base types was extracted from

The types are all the supported primitive + structured types in `JSON-RPC 2.0` other than null.