### PR TITLE
Add support for external tools

### DIFF
--- a/lib/tidewave.ex
+++ b/lib/tidewave.ex
@@ -4,9 +4,13 @@ defmodule Tidewave do
 
   @impl true
   def init(opts) do
+    external_tools = Keyword.get(opts, :external_tools, nil)
+    init_external_tools(external_tools)
+
     %{
       allowed_origins: Keyword.get(opts, :allowed_origins, nil),
       allow_remote_access: Keyword.get(opts, :allow_remote_access, false),
+      external_tools: external_tools,
       phoenix_endpoint: nil,
       inspect_opts:
         Keyword.get(opts, :inspect_opts, charlists: :as_lists, limit: 50, pretty: true)
@@ -41,5 +45,33 @@ defmodule Tidewave do
 
   defp request_body_parsed?(conn) do
     not match?(%Plug.Conn.Unfetched{}, conn.body_params)
+  end
+
+  defp init_external_tools(nil), do: :ok
+
+  defp init_external_tools(module_names) do
+    new_tools =
+      module_names
+      |> Enum.uniq()
+      |> Enum.flat_map(& &1.tools())
+
+    dispatch_map =
+      Map.new(new_tools, &{&1.name, &1.callback})
+
+    add_tools(new_tools, dispatch_map)
+  end
+
+  defp add_tools(new_tools, dispatch_map) do
+    {old_tools, old_dispatch_map} =
+      case :ets.lookup(:tidewave_tools, :tools) do
+        [{:tools, {tools, dmap}}] -> {tools, dmap}
+        [] -> {[], %{}}
+      end
+
+    new_tools = Enum.reject(new_tools, &(&1 in old_tools))
+    updated_tools = old_tools ++ new_tools
+    updated_dispatch_map = Map.merge(old_dispatch_map, dispatch_map)
+
+    :ets.insert(:tidewave_tools, {:tools, {updated_tools, updated_dispatch_map}})
   end
 end

--- a/lib/tidewave/mcp/server.ex
+++ b/lib/tidewave/mcp/server.ex
@@ -29,7 +29,7 @@ defmodule Tidewave.MCP.Server do
 
     # TODO: switch back to persistent_term when we don't support OTP 27 any more
     # :persistent_term.put({__MODULE__, :tools_and_dispatch}, {tools, dispatch_map})
-    :ets.new(:tidewave_tools, [:set, :named_table, read_concurrency: true])
+    :ets.new(:tidewave_tools, [:set, :public, :named_table, read_concurrency: true])
     :ets.insert(:tidewave_tools, {:tools, {tools, dispatch_map}})
   end
 

--- a/test/support/mock_tool.ex
+++ b/test/support/mock_tool.ex
@@ -1,0 +1,36 @@
+defmodule Tidewave.MockTool do
+  def tools do
+    [
+      %{
+        name: "mock_tool",
+        description: """
+        mock_tool
+        """,
+        inputSchema: %{
+          type: "object",
+          required: ["q"],
+          properties: %{
+            q: %{
+              type: "string",
+              description: "mock_description"
+            },
+            packages: %{
+              type: "array",
+              items: %{
+                type: "string"
+              },
+              description: """
+              mock_description
+              """
+            }
+          }
+        },
+        callback: &mock_callback/1
+      }
+    ]
+  end
+
+  def mock_callback(_args) do
+    {:ok, "mock_tool"}
+  end
+end


### PR DESCRIPTION
Hello, I am from the LiveDebugger team, and we have decided to add a new functionality to Tidewave - the ability to add your own custom external tools.
I have implemented a custom tool here:
https://github.com/software-mansion/live-debugger/compare/main...tidewave_mcp_tools

To add it to Tidewave, you need to include the following line in the plug configuration:

<pre>if Code.ensure_loaded?(Tidewave) do
plug(Tidewave,
external_tools: [LiveDebugger.TidewaveMcp.Tools.SeeActiveLiveViews],
)
end </pre>

Here is an example of how it works:
<img width="402" height="422" alt="Screenshot 2025-09-03 at 10 50 17" src="https://github.com/user-attachments/assets/16f8aa40-69fa-4728-8545-397614062472" />


Let me know what do you think!