### PR TITLE
Add troubleshooting point for MCP proxy and HTTP 405

### DIFF
--- a/pages/mcp/mcp_troubleshooting.md
+++ b/pages/mcp/mcp_troubleshooting.md
@@ -65,6 +65,17 @@ If the MCP proxy does not work, here is what you can try to debug it:
     ```
     echo '{"jsonrpc":"2.0","id":1,"method":"ping"}' | /path/to/mcp-proxy http://localhost:$PORT/tidewave/mcp
     ```
+  * If you are getting HTTP error 405 (Method Not Allowed), try adding `--transport=streamablehttp` option, i.e.:
+    ```
+    echo '{"jsonrpc":"2.0","id":1,"method":"ping"}' | /path/to/mcp-proxy http://localhost:$PORT/tidewave/mcp --transport=streamablehttp
+    ```
+    If it helps, adjust your MCP configuration in the editor, for example:
+    ```json
+    "tidawave": {
+      "command": "mcp-proxy",
+      "args": ["http://localhost:4000/tidewave/mcp", "--transport=streamablehttp"]
+    }
+    ```
   * Our Rust proxy accepts a `--debug` parameter, which logs helpful debugging information on stderr.
 
 ## Your editor


### PR DESCRIPTION
This happened to me (HTTP 405) and I spent a while figuring out that I needed to add an option for `mcp-proxy` command. Sharing it in the docs in case someone has similar problems.

For context, I installed `mcp-proxy` using `uv` and the version is 0.8.2.