### PR TITLE
Add log level filtering to get_logs MCP tool

### DIFF
--- a/lib/tidewave/mcp/logger.ex
+++ b/lib/tidewave/mcp/logger.ex
@@ -3,13 +3,18 @@ defmodule Tidewave.MCP.Logger do
 
   use GenServer
 
+  @levels Map.new(~w[emergency alert critical error warning notice info debug]a, &{"#{&1}", &1})
+
   def start_link(_) do
     GenServer.start_link(__MODULE__, nil, name: __MODULE__)
   end
 
-  def get_logs(n, grep \\ nil) do
+  def get_logs(n, opts \\ []) do
+    grep = Keyword.get(opts, :grep)
     regex = grep && Regex.compile!(grep, "iu")
-    GenServer.call(__MODULE__, {:get_logs, n, regex})
+    level = Keyword.get(opts, :level)
+    level_atom = level && Map.fetch!(@levels, level)
+    GenServer.call(__MODULE__, {:get_logs, n, regex, level_atom})
   end
 
   def clear_logs do
@@ -17,13 +22,13 @@ defmodule Tidewave.MCP.Logger do
   end
 
   # Erlang/OTP log handler
-  def log(%{meta: meta} = event, config) do
+  def log(%{meta: meta, level: level} = event, config) do
     if meta[:tidewave_mcp] do
       :ok
     else
       %{formatter: {formatter_mod, formatter_config}} = config
       chardata = formatter_mod.format(event, formatter_config)
-      GenServer.cast(__MODULE__, {:log, IO.chardata_to_string(chardata)})
+      GenServer.cast(__MODULE__, {:log, level, IO.chardata_to_string(chardata)})
     end
   end
 
@@ -31,26 +36,35 @@ defmodule Tidewave.MCP.Logger do
     {:ok, %{cb: CircularBuffer.new(1024)}}
   end
 
-  def handle_cast({:log, message}, state) do
+  def handle_cast({:log, level, message}, state) do
     # There is a built-in way for MCPs to expose log messages,
     # but we currently don't use it, as the client support isn't really there.
     # https://spec.modelcontextprotocol.io/specification/2024-11-05/server/utilities/logging/
-    cb = CircularBuffer.insert(state.cb, message)
+    cb = CircularBuffer.insert(state.cb, {level, message})
 
     {:noreply, %{state | cb: cb}}
   end
 
-  def handle_call({:get_logs, n, regex}, _from, state) do
+  def handle_call({:get_logs, n, regex, level_filter}, _from, state) do
     logs = CircularBuffer.to_list(state.cb)
 
     logs =
-      if regex do
-        Stream.filter(logs, &Regex.match?(regex, &1))
+      if level_filter do
+        Stream.filter(logs, fn {level, _message} -> level == level_filter end)
       else
         logs
       end
 
-    {:reply, Enum.take(logs, -n), state}
+    logs =
+      if regex do
+        Stream.filter(logs, fn {_level, message} -> Regex.match?(regex, message) end)
+      else
+        logs
+      end
+
+    messages = Stream.map(logs, &elem(&1,1))
+
+    {:reply, Enum.take(messages, -n), state}
   end
 
   def handle_call(:clear_logs, _from, state) do

--- a/lib/tidewave/mcp/tools/logs.ex
+++ b/lib/tidewave/mcp/tools/logs.ex
@@ -21,7 +21,12 @@ defmodule Tidewave.MCP.Tools.Logs do
             grep: %{
               type: "string",
               description:
-                "Filter logs with the given regular expression (case insensitive). E.g. \"error\" when you want to capture errors in particular"
+                "Filter logs with the given regular expression (case insensitive). E.g. \"timeout\" to find timeout-related messages"
+            },
+            level: %{
+              type: "string",
+              enum: ["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"],
+              description: "Filter logs by log level (e.g. \"error\" for error logs only)"
             }
           }
         },
@@ -33,8 +38,14 @@ defmodule Tidewave.MCP.Tools.Logs do
   def get_logs(args) do
     case args do
       %{"tail" => n} ->
-        grep = Map.get(args, "grep")
-        {:ok, Enum.join(Tidewave.MCP.Logger.get_logs(n, grep), "\n")}
+        opts =
+          [
+            grep: Map.get(args, "grep"),
+            level: Map.get(args, "level")
+          ]
+          |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+
+        {:ok, Enum.join(Tidewave.MCP.Logger.get_logs(n, opts), "\n")}
 
       _ ->
         {:error, :invalid_arguments}


### PR DESCRIPTION
- Add `level` parameter with Erlang log levels enum
- Store {level, message} tuples in circular buffer
- Change get_logs/2 to accept keyword list options
- Update grep description to avoid "error" example
- Add tests for level filtering