### PR TITLE
Revert "Add the proper types to the item schema in both the ecto and eval tools"

### DIFF
--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -58,7 +58,7 @@ defmodule Tidewave.MCP.Tools.Ecto do
                 type: "array",
                 description:
                   "The arguments to pass to the query. The query must contain corresponding parameters",
-                items: %{type: ["array", "boolean", "null", "number", "object", "string"]}
+                items: %{}
               }
             }
           },

--- a/lib/tidewave/mcp/tools/eval.ex
+++ b/lib/tidewave/mcp/tools/eval.ex
@@ -35,7 +35,7 @@ defmodule Tidewave.MCP.Tools.Eval do
               type: "array",
               description:
                 "The arguments to pass to evaluation. They are available inside the evaluated code as `arguments`",
-              items: %{type: ["array", "boolean", "null", "number", "object", "string"]}
+              items: %{}
             },
             timeout: %{
               type: "integer",


### PR DESCRIPTION
GPT failed with reason: Invalid schema for function 'project_eval': In context=('properties', 'arguments', 'items', 'type', '0'), array schema missing items.

Reverts tidewave-ai/tidewave_phoenix#223