### PR TITLE
Add the proper types to the item schema in both the ecto and eval tools

### DIFF
--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -30,6 +30,21 @@ defmodule Tidewave.MCP.Tools.Ecto do
           in PostgreSQL or using `BIN_TO_UUID(column)` on databases like MySQL.
           """,
           inputSchema: %{
+            "$defs" => %{
+              "anyValue" => %{
+                "anyOf" => [
+                  %{"type" => "boolean"},
+                  %{"type" => "null"},
+                  %{"type" => "number"},
+                  %{"type" => "object"},
+                  %{"type" => "string"},
+                  %{
+                    "type" => "array",
+                    "items" => %{"type" => ["boolean", "null", "number", "object", "string"]}
+                  }
+                ]
+              }
+            },
             type: "object",
             required: ["query"],
             properties: %{
@@ -58,7 +73,7 @@ defmodule Tidewave.MCP.Tools.Ecto do
                 type: "array",
                 description:
                   "The arguments to pass to the query. The query must contain corresponding parameters",
-                items: %{}
+                items: %{"$ref" => "#/$defs/anyValue"}
               }
             }
           },

--- a/lib/tidewave/mcp/tools/eval.ex
+++ b/lib/tidewave/mcp/tools/eval.ex
@@ -24,6 +24,21 @@ defmodule Tidewave.MCP.Tools.Eval do
         `exports(String)`.
         """,
         inputSchema: %{
+          "$defs" => %{
+            "anyValue" => %{
+              "anyOf" => [
+                %{"type" => "boolean"},
+                %{"type" => "null"},
+                %{"type" => "number"},
+                %{"type" => "object"},
+                %{"type" => "string"},
+                %{
+                  "type" => "array",
+                  "items" => %{"type" => ["boolean", "null", "number", "object", "string"]}
+                }
+              ]
+            }
+          },
           type: "object",
           required: ["code"],
           properties: %{
@@ -35,7 +50,7 @@ defmodule Tidewave.MCP.Tools.Eval do
               type: "array",
               description:
                 "The arguments to pass to evaluation. They are available inside the evaluated code as `arguments`",
-              items: %{}
+              items: %{"$ref" => "#/$defs/anyValue"}
             },
             timeout: %{
               type: "integer",


### PR DESCRIPTION
This time I've tested it works with Opus, Codex, Gemini, and Kimi.

Opencode session: https://opncd.ai/share/tK0e0Hf7