### PR TITLE
add spark context information to ecto tools

### DIFF
--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -131,9 +131,9 @@ defmodule Tidewave.MCP.Tools.Ecto do
             _ -> ""
           end
 
-        ash_context = spark_is_context(module)
+        spark_context = spark_is_context(module)
 
-        "* #{inspect(module)}#{location}#{ash_context}"
+        "* #{inspect(module)}#{location}#{spark_context}"
       end
 
     case schemas do


### PR DESCRIPTION
This will only meaningfully impact Ash resources, but its written in such a way as to work for any case where an Ecto schema is extended by a [Spark](https://hexdocs.pm/spark) DSL.