### PR TITLE
Add :ecto_apps config for additional Ecto app discovery

### DIFF
--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -160,7 +160,7 @@ defmodule Tidewave.MCP.Tools.Ecto do
         [Mix.Project.config()[:app]]
       end
 
-    extra = Application.get_env(:tidewave, :ecto_apps, [])
+    extra = Application.get_env(:tidewave, :extra_apps, [])
     Enum.uniq(discovered ++ extra)
   end
 


### PR DESCRIPTION
Adds a `:tidewave, :ecto_apps` config option that lets users specify additional apps to scan for Ecto repos. I added this because the automatic discovery didn't work with our setup at work. We have libraries that contain ecto repos that are shared across multiple applications.

## Usage

```elixir
config :tidewave, ecto_apps: [:my_other_app]
```