### PR TITLE
feat: recompile project before all tool calls that depend on fresh compilation

### DIFF
--- a/lib/tidewave/mcp/server.ex
+++ b/lib/tidewave/mcp/server.ex
@@ -72,11 +72,17 @@ defmodule Tidewave.MCP.Server do
 
     case dispatch do
       %{^name => {callback, recompile}} ->
-        if recompile, do: maybe_reload(assigns)
+        reload_result = if recompile, do: maybe_reload(assigns), else: :ok
 
-        case Function.info(callback, :arity) do
-          {:arity, 2} -> callback.(args, assigns)
-          {:arity, 1} -> callback.(args)
+        case reload_result do
+          :ok ->
+            case Function.info(callback, :arity) do
+              {:arity, 2} -> callback.(args, assigns)
+              {:arity, 1} -> callback.(args)
+            end
+
+          {:error, _} = error ->
+            error
         end
 
       _ ->
@@ -94,15 +100,34 @@ defmodule Tidewave.MCP.Server do
   defp maybe_reload(assigns) do
     cond do
       endpoint = assigns[:phoenix_endpoint] ->
-        Phoenix.CodeReloader.reload(endpoint)
+        case Phoenix.CodeReloader.reload(endpoint) do
+          :ok -> :ok
+          {:error, output} -> {:error, "Compilation failed:\n\n#{output}"}
+        end
 
       Application.get_env(:tidewave, :recompile_on_tool_call, false) and
           Code.ensure_loaded?(IEx.Helpers) ->
-        IEx.Helpers.recompile()
+        try do
+          with_build_lock(fn ->
+            case IEx.Helpers.recompile() do
+              :ok -> :ok
+              :error -> {:error, "Compilation failed. Check your terminal output for details."}
+            end
+          end)
+        catch
+          kind, reason ->
+            {:error, "Compilation failed: #{Exception.format(kind, reason, __STACKTRACE__)}"}
+        end
 
       true ->
         :ok
     end
+  end
+
+  if Code.ensure_loaded?(Mix.Project) and function_exported?(Mix.Project, :with_build_lock, 1) do
+    defp with_build_lock(fun), do: Mix.Project.with_build_lock(fun)
+  else
+    defp with_build_lock(fun), do: fun.()
   end
 
   ## MCP message processing

--- a/lib/tidewave/mcp/server.ex
+++ b/lib/tidewave/mcp/server.ex
@@ -6,6 +6,8 @@ defmodule Tidewave.MCP.Server do
   import Plug.Conn
   alias Tidewave.MCP.Tools
 
+  @compile {:no_warn_undefined, {Phoenix.CodeReloader, :reload, 1}}
+
   @protocol_version "2025-03-26"
   @vsn Mix.Project.config()[:version]
 
@@ -26,7 +28,11 @@ defmodule Tidewave.MCP.Server do
   @doc false
   def init_tools do
     tools = raw_tools()
-    dispatch_map = Map.new(tools, fn tool -> {tool.name, tool.callback} end)
+
+    dispatch_map =
+      Map.new(tools, fn tool ->
+        {tool.name, {tool.callback, Map.get(tool, :recompile, false)}}
+      end)
 
     # TODO: switch back to persistent_term when we don't support OTP 27 any more
     # :persistent_term.put({__MODULE__, :tools_and_dispatch}, {tools, dispatch_map})
@@ -48,7 +54,7 @@ defmodule Tidewave.MCP.Server do
     for tool <- tools do
       tool
       |> Map.put(:description, String.trim(tool.description))
-      |> Map.drop([:callback])
+      |> Map.drop([:callback, :recompile])
     end
   end
 
@@ -65,11 +71,13 @@ defmodule Tidewave.MCP.Server do
     {_tools, dispatch} = tools_and_dispatch()
 
     case dispatch do
-      %{^name => callback} when is_function(callback, 2) ->
-        callback.(args, assigns)
+      %{^name => {callback, recompile}} ->
+        if recompile, do: maybe_reload(assigns)
 
-      %{^name => callback} when is_function(callback, 1) ->
-        callback.(args)
+        case Function.info(callback, :arity) do
+          {:arity, 2} -> callback.(args, assigns)
+          {:arity, 1} -> callback.(args)
+        end
 
       _ ->
         {:error,
@@ -80,6 +88,20 @@ defmodule Tidewave.MCP.Server do
              name: name
            }
          }}
+    end
+  end
+
+  defp maybe_reload(assigns) do
+    cond do
+      endpoint = assigns[:phoenix_endpoint] ->
+        Phoenix.CodeReloader.reload(endpoint)
+
+      Application.get_env(:tidewave, :recompile_on_tool_call, false) and
+          Code.ensure_loaded?(IEx.Helpers) ->
+        IEx.Helpers.recompile()
+
+      true ->
+        :ok
     end
   end
 

--- a/lib/tidewave/mcp/tools/ash.ex
+++ b/lib/tidewave/mcp/tools/ash.ex
@@ -26,7 +26,9 @@ defmodule Tidewave.MCP.Tools.Ash do
             properties: %{}
           },
           annotations: %{readOnlyHint: true},
-          callback: &get_ash_resources/1
+
+          callback: &get_ash_resources/1,
+          recompile: true
         }
       ]
     else

--- a/lib/tidewave/mcp/tools/ecto.ex
+++ b/lib/tidewave/mcp/tools/ecto.ex
@@ -78,7 +78,8 @@ defmodule Tidewave.MCP.Tools.Ecto do
             properties: %{}
           },
           annotations: %{readOnlyHint: true},
-          callback: &get_ecto_schemas/1
+          callback: &get_ecto_schemas/1,
+          recompile: true
         }
       ]
     else

--- a/lib/tidewave/mcp/tools/eval.ex
+++ b/lib/tidewave/mcp/tools/eval.ex
@@ -1,8 +1,6 @@
 defmodule Tidewave.MCP.Tools.Eval do
   @moduledoc false
 
-  @compile {:no_warn_undefined, Phoenix.CodeReloader}
-
   alias Tidewave.MCP.StandardError
 
   def tools do
@@ -44,7 +42,8 @@ defmodule Tidewave.MCP.Tools.Eval do
             }
           }
         },
-        callback: &project_eval/2
+        callback: &project_eval/2,
+        recompile: true
       }
     ]
   end
@@ -69,11 +68,6 @@ defmodule Tidewave.MCP.Tools.Eval do
 
   defp eval_code(code, arguments, timeout, json?, assigns) do
     parent = self()
-
-    if endpoint = assigns[:phoenix_endpoint] do
-      Phoenix.CodeReloader.reload(endpoint)
-    end
-
     inspect_opts = assigns.inspect_opts
 
     {pid, ref} =

--- a/lib/tidewave/mcp/tools/source.ex
+++ b/lib/tidewave/mcp/tools/source.ex
@@ -30,7 +30,9 @@ defmodule Tidewave.MCP.Tools.Source do
           }
         },
         annotations: %{readOnlyHint: true},
-        callback: &get_source_location/1
+
+        callback: &get_source_location/1,
+        recompile: true
       },
       %{
         name: "get_docs",
@@ -53,7 +55,9 @@ defmodule Tidewave.MCP.Tools.Source do
           }
         },
         annotations: %{readOnlyHint: true},
-        callback: &get_docs/1
+
+        callback: &get_docs/1,
+        recompile: true
       }
     ]
   end

--- a/test/mcp/tools_test.exs
+++ b/test/mcp/tools_test.exs
@@ -4,9 +4,12 @@ defmodule Tidewave.MCP.ToolsTest do
   test "tools have valid callbacks" do
     {_, dispatch_map} = Tidewave.MCP.Server.tools_and_dispatch()
 
-    for {tool, callback} <- dispatch_map do
+    for {tool, {callback, recompile}} <- dispatch_map do
       assert is_function(callback, 1) or is_function(callback, 2),
              "#{tool} does not have a valid callback #{inspect(callback)}"
+
+      assert is_boolean(recompile),
+             "#{tool} does not have a valid recompile flag #{inspect(recompile)}"
     end
   end
 end


### PR DESCRIPTION
## Description

Tools like project_eval, get_source_location, get_docs, get_ecto_schemas, and get_ash_resources now trigger recompilation before executing, ensuring they operate on up-to-date code rather than stale compiled modules.

For non-Phoenix projects where Phoenix.CodeReloader is unavailable, an opt-in fallback uses IEx.Helpers.recompile(), enabled by setting `config :tidewave, recompile_on_tool_call: true`.

Happy to make any changes to this PR if requested 😄 