### PR TITLE
Document CLAUDE_CODE_EXECUTABLE override

### DIFF
--- a/pages/providers/claude_code.md
+++ b/pages/providers/claude_code.md
@@ -26,9 +26,14 @@ CLAUDE_CODE_EXECUTABLE = "..."
 
 If you are using the CLI, you can set those variables when starting the CLI.
 
-> #### Custom `claude-agent-acp` installation {: .info}
+> #### Custom `claude-agent-acp` and `claude` installation {: .info}
 >
-> Tidewave talks to Claude Code using the [Claude Agent ACP](https://github.com/zed-industries/claude-agent-acp) project. It is possible to use a custom `claude-agent-acp` executable by setting the `TIDEWAVE_CLAUDE_AGENT_ACP_EXECUTABLE` environment variable when starting your web application. This is rarely needed in practice but it may be required in some operating systems like NixOS.
+> Tidewave talks to Claude Code using the [Claude Agent ACP](https://github.com/zed-industries/claude-agent-acp) project. It is possible to use custom `claude-agent-acp` and `claude` executables by setting the `TIDEWAVE_CLAUDE_AGENT_ACP_EXECUTABLE` and `CLAUDE_CODE_EXECUTABLE` environment variables when starting your web application. This is rarely needed in practice but it may be required in some operating systems such as NixOS. Example variables for NixOS:
+> 
+> ```
+> TIDEWAVE_CLAUDE_AGENT_ACP_EXECUTABLE = "/run/current-system/sw/bin/claude-agent-acp"
+> CLAUDE_CODE_EXECUTABLE = "/run/current-system/sw/bin/claude"
+> ```
 
 ## FAQ
 


### PR DESCRIPTION
In NixOS without the `CLAUDE_CODE_EXECUTABLE` env var set, Tidewave Web showed "Failed to load models" and trying to run Claude with the Open Terminal button showed:

```
/run/current-system/sw/bin/claude-agent-acp --cli
  Could not start dynamically linked executable:
  /nix/store/c5i4k60ga30zk9vp76ck827djpcv3ah3-claude-agent-acp-0.32.0/lib/node_modules/@agentclientprotocol/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude
  NixOS cannot run dynamically linked executables intended for generic
  linux environments out of the box. For more information, see:
  https://nix.dev/permalink/stub-ld
```