### PR TITLE
Ignore already sent responses

### DIFF
--- a/lib/tidewave.ex
+++ b/lib/tidewave.ex
@@ -52,9 +52,14 @@ defmodule Tidewave do
     conn
     |> validate!()
     |> Plug.Conn.register_before_send(fn conn ->
-      conn
-      |> maybe_rewrite_csp()
-      |> Plug.Conn.delete_resp_header("x-frame-options")
+      try do
+        conn
+        |> maybe_rewrite_csp()
+        |> Plug.Conn.delete_resp_header("x-frame-options")
+      rescue
+        Plug.Conn.AlreadySentError ->
+          conn
+      end
     end)
   end
 


### PR DESCRIPTION
Closes https://github.com/tidewave-ai/tidewave_phoenix/issues/247.

Since Plug does not expose the full status list of what is considered already sent, rescuing is cleanest, I think.